### PR TITLE
Fixes printSummary so that it won't cause the gulp task to never finish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Stylish reporter for gulp-scss-lint, following the visual style of ESLint stylish reporter
 
-[![dependencies](https://david-dm.org/jsek/gulp-scss-lint-stylish2.png)](https://david-dm.org/jsek/gulp-scss-lint-stylish2) 
+[![dependencies](https://david-dm.org/jsek/gulp-scss-lint-stylish2.png)](https://david-dm.org/jsek/gulp-scss-lint-stylish2)
 [![licence](https://img.shields.io/npm/l/gulp-scss-lint-stylish2.svg)](https://github.com/jsek/gulp-scss-lint-stylish2/blob/master/LICENSE)
-[![npm version](http://img.shields.io/npm/v/gulp-scss-lint-stylish2.svg)](https://npmjs.org/package/gulp-scss-lint-stylish2) 
-[![downloads](https://img.shields.io/npm/dm/gulp-scss-lint-stylish2.svg)](https://npmjs.org/package/gulp-scss-lint-stylish2) 
+[![npm version](http://img.shields.io/npm/v/gulp-scss-lint-stylish2.svg)](https://npmjs.org/package/gulp-scss-lint-stylish2)
+[![downloads](https://img.shields.io/npm/dm/gulp-scss-lint-stylish2.svg)](https://npmjs.org/package/gulp-scss-lint-stylish2)
 
 * [Overview](#overview)
 * [Installation](#installation)
@@ -27,14 +27,14 @@ npm install --save gulp-scss-lint-stylish2
 var gulp     = require('gulp'),
     scssLint = require('gulp-scss-lint'),
     stylish  = require('gulp-scss-lint-stylish2');
- 
+
 gulp.task('scss-lint', function()
 {
     var reporter = stylish();
 
     gulp.src('/scss/*.scss')
         .pipe( scssLint({ customReport: reporter.issues }) )
-        .pipe( reporter.printSummary );
+        .pipe( reporter.printSummary() );
 });
 ```
 
@@ -50,7 +50,7 @@ You can list just the files:
 
 ``` javascript
         .pipe( scssLint({ customReport: reporter.files }) )
-        .pipe( reporter.printSummary );
+        .pipe( reporter.printSummary() );
 ```
 
 ![screenshot](images/screenshot_2.0.0-files.png)
@@ -59,7 +59,7 @@ You can list just the files:
 
 ``` javascript
         .pipe( scssLint({ customReport: reporter.silent }) )
-        .pipe( reporter.printSummary );
+        .pipe( reporter.printSummary() );
 ```
 
 ![screenshot](images/screenshot_2.0.0-silent.png)

--- a/index.coffee
+++ b/index.coffee
@@ -10,20 +10,20 @@ through = require('through2')
 lastFailingFile = null
 cl = gutil.colors
 
-severityColor = 
+severityColor =
     warning : cl.yellow
-    error   : cl.red 
+    error   : cl.red
 
 #------------------------------------------------------------------------------
 # Helpers
 #------------------------------------------------------------------------------
 
-printPath     = (path) -> 
+printPath     = (path) ->
     filename = path.match(new RegExp("([^\\\\]+)\\.[a-zA-Z]+$"))[1]
     extension = path.match(new RegExp("\\.([a-zA-Z]+)$"))[1]
     dir = path.slice(0, path.length - filename.length - extension.length - 1)
     return '\n' + cl.magenta(dir) + cl.yellow(filename) + cl.magenta('.' + extension)
-    
+
 printPlaceRaw = (issue) -> "(#{issue.line},#{issue.column})"
 printSeverity = (issue) -> severityColor[issue.severity](issue.severity)
 printLinter   = (issue) -> cl.gray(issue.linter)
@@ -45,8 +45,8 @@ logStylish    = (issues) ->
             issue.reason
             printLinter issue
         ]
-        
-    tableOptions = 
+
+    tableOptions =
         align: ["", "r", "l"],
         stringLength: (str) -> cl.stripColor(str).length
 
@@ -76,11 +76,11 @@ stylishPrintErrorsInFile = (file) ->
     if file.scsslint.errors > 0
         printPathLine file
         logStylish file.scsslint.issues.filter((x) -> x.severity is 'error')
-    
+
 stylishSummary = (total, errors, warnings) ->
     if total > 0
         console.log cl.red.bold "\n\u2716  #{total} #{pluralize('problem', total)} (#{errors} #{pluralize('error', errors)}, #{warnings} #{pluralize('warning', warnings)})\n"
-    
+
 stylishErrorsSummary = (total, errors, warnings) ->
     if total > 0
         console.log cl.red.bold "\n\u2716  #{errors} #{pluralize('error', errors)}!\n"
@@ -90,12 +90,12 @@ writeSuccess = ->
 
 writeStylishResults = (results, summaryFormatter) ->
     total = errors = warnings = 0
-    
+
     for result in results
         total += result.scsslint.issues.length
         errors += result.scsslint.errors
         warnings += result.scsslint.warnings
-        
+
     if total > 0 then summaryFormatter(total, errors, warnings)
 
 reportWithSummary = (fileFormatter, summaryFormatter) ->
@@ -107,22 +107,26 @@ reportWithSummary = (fileFormatter, summaryFormatter) ->
                 fileIssues = fileFormatter(file)
                 if fileIssues
                     process.stderr.write(fileIssues + '\n')
-        
+
         silent: (file, stream) ->
             unless file.scsslint.success
                 results.push file
-            
+
         files: (file, stream) ->
             unless file.scsslint.success
                 results.push file
                 process.stderr.write printPath(file.path)
-        
-        printSummary: through.obj passThrough, ->
-            if results.length > 0
-                writeStylishResults(results, summaryFormatter);
-            else
-                writeSuccess();
-            results = []
+
+        printSummary: () ->
+            through.obj passThrough, ->
+                if results.length > 0
+                    writeStylishResults(results, summaryFormatter);
+                else
+                    writeSuccess();
+
+                @emit 'end'
+
+                results = []
     }
 
 stylishReporter = (opts) ->

--- a/index.js
+++ b/index.js
@@ -165,14 +165,17 @@ reportWithSummary = function(fileFormatter, summaryFormatter) {
         return process.stderr.write(printPath(file.path));
       }
     },
-    printSummary: through.obj(passThrough, function() {
-      if (results.length > 0) {
-        writeStylishResults(results, summaryFormatter);
-      } else {
-        writeSuccess();
-      }
-      return results = [];
-    })
+    printSummary: function() {
+      return through.obj(passThrough, function() {
+        if (results.length > 0) {
+          writeStylishResults(results, summaryFormatter);
+        } else {
+          writeSuccess();
+        }
+        this.emit('end');
+        return results = [];
+      });
+    }
   };
 };
 


### PR DESCRIPTION
- Added `this.emit('end')` to `printSummary` so that tasks using this plugin will not longer hang. (Here is one of the many examples I can find online of this issue: http://stackoverflow.com/questions/28705672/why-does-gulp-quit-without-finishing-my-task)
- Made `printSummary` a function that returns the result of `through.obj(...)`. It is the convention of Gulp to pass the results of functions as the "plugin parameter" of `pipe` rather than a straight up stream. Feel free disagree with me on this, I have no problem changing it back to a non-function.
- My Sublime Text settings automatically removed all trailing spaces on save, sorry for that, that's why it will look like there are a lot more changes than there really are in the diffs.

Let me know if you want me to make any other changes before you'll merge this pull request, I'm happy to comply with your conventions/standards/etc.

Thanks.
